### PR TITLE
lab1: změna formulace pro neúspěšné sudo

### DIFF
--- a/wireshark_ip_konfigurace/lab1-zadani.tex
+++ b/wireshark_ip_konfigurace/lab1-zadani.tex
@@ -37,7 +37,7 @@ v~sekci \ref{basic_ipconfig} laboratorního manuálu --- Konfigurace síťových
 \item Vypište aktivní TCP spojení, vyberte jeden záznam, zapište si ho a popište význam jednotlivých položek. Pokud se žádné TCP spojení nezobrazuje, nějaké vygenerujte, například pomocí webového prohlížeče.
 \item Zobrazte systémové události pomocí programu \texttt{journalctl}.
 \item Zobrazte pouze události týkající se NetworkManager.
-\item Pokuste se jako uživatel user spustit Wireshark s pomocí programu \texttt{sudo}. Následně nalezněte v~logu zprávu, která byla zaznamenána v~případě neúspěšného přihlášení.
+\item Pokuste se jako uživatel user spustit Wireshark s pomocí programu \texttt{sudo}. Následně nalezněte v~logu zprávu, která byla zaznamenána v~případě správně zadaného hesla, ale odepřeného přístupu.
 \end{enumerate}
 
 \section{Wireshark}


### PR DESCRIPTION
Při plnění úkolu (sudo wireshark) je možné vygenerovat 2 druhy hlášek - jednu v případě správně zadaného hesla, druhou v případě špatně zadaného hesla. Při cvičení mi nebylo jasné, kterou z těchto hlášek mám zapsat do záznamového archu a na dotaz mi bylo řečeno, že tu při správně zadanému heslu. Proto navrhuji nějakým způsobem přeformulovat tuto větu, např. tak jako je to v tomto pull requestu.