### PR TITLE
Bugfix/management oid typo

### DIFF
--- a/manual/management.tex
+++ b/manual/management.tex
@@ -64,7 +64,7 @@ Služba SNMP (Simple Network Monitoring Protocol) slouží k aktivnímu monitoro
 
 Řídicí stanice NMS posílá zprávy SNMP na jednotlivá síťová zařízení s cílem získat hodnoty sledovaných objektů systému. Standardní způsob komunikace pracuje na principu vyzývání (polling), kdy řídicí stanice NMS periodicky posílá zprávy typu dotaz na sledovaná zařízení. Požadované hodnoty (objekty MIB) jsou identifikovány pomocí tzv. OID (Object Identifier), které jsou standardizovány v databázi MIB (Management Information Base).
 
-Příkladem objektu je {\tt sysDescr} (System Description) s OID {\tt 1.3.6.1.2.1.1.6.0}. Standardizované objekty jsou uloženy v databázi MIB-2, která je definována standardem RFC 1213 \cite{rfc1213}.
+Příkladem objektu je {\tt sysDescr} (System Description) s OID {\tt 1.3.6.1.2.1.1.1}. Standardizované objekty jsou uloženy v databázi MIB-2, která je definována standardem RFC 1213 \cite{rfc1213}.
 
 Pro vyhledávání objektů SNMP lze využít následující portály:
 \begin{itemize}

--- a/manual/management.tex
+++ b/manual/management.tex
@@ -64,7 +64,7 @@ Služba SNMP (Simple Network Monitoring Protocol) slouží k aktivnímu monitoro
 
 Řídicí stanice NMS posílá zprávy SNMP na jednotlivá síťová zařízení s cílem získat hodnoty sledovaných objektů systému. Standardní způsob komunikace pracuje na principu vyzývání (polling), kdy řídicí stanice NMS periodicky posílá zprávy typu dotaz na sledovaná zařízení. Požadované hodnoty (objekty MIB) jsou identifikovány pomocí tzv. OID (Object Identifier), které jsou standardizovány v databázi MIB (Management Information Base).
 
-Příkladem objektu je {\tt sysDescr} (System Description) s OID {\tt 1.3.6.1.2.1.1.1}. Standardizované objekty jsou uloženy v databázi MIB-2, která je definována standardem RFC 1213 \cite{rfc1213}.
+Příkladem objektu je {\tt sysDescr} (System Description) s OID {\tt 1.3.6.1.2.1.1.1.0}. Standardizované objekty jsou uloženy v databázi MIB-2, která je definována standardem RFC 1213 \cite{rfc1213}.
 
 Pro vyhledávání objektů SNMP lze využít následující portály:
 \begin{itemize}


### PR DESCRIPTION
Small typo.

sysDescr object has OID 1.3.6.1.2.1.1.1 (https://www.alvestrand.no/objectid/1.3.6.1.2.1.1.1.html) therefore an instance of such object should have OID 1.3.6.1.2.1.1.1.0

Corrected from 1.3.6.1.2.1.1.6.0, being the OID of an instance of sysLocation (https://www.alvestrand.no/objectid/1.3.6.1.2.1.1.6.html) 